### PR TITLE
Add support for multiple outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2020-05-17
+### Added
+- [Pubsub] Add support for multiple outputs
+
 ## [1.9.0] - 2019-12-02
 ### Added
 - [Server] Allow timeouts to be configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.9.1] - 2020-05-17
+## [1.10.0] - 2020-05-17
 ### Added
 - [Pubsub] Add support for multiple outputs
 

--- a/surfkit.go
+++ b/surfkit.go
@@ -6,7 +6,7 @@ import (
 	"github.com/helloink/surfkit/events"
 )
 
-const version = "1.9.0"
+const version = "1.9.1"
 
 // Output defines the single channel on which the service produces output, given it is a Pubsub output.
 // Eventually this should also cover HTTP Endpoints.

--- a/surfkit.go
+++ b/surfkit.go
@@ -6,7 +6,7 @@ import (
 	"github.com/helloink/surfkit/events"
 )
 
-const version = "1.9.1"
+const version = "1.10.0"
 
 // Output defines the single channel on which the service produces output, given it is a Pubsub output.
 // Eventually this should also cover HTTP Endpoints.


### PR DESCRIPTION
This lets users specify a single output or a slice of outputs or both.